### PR TITLE
Configured ml-api for Drone.io CI/CD

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,20 @@
+pipeline:
+  build_and_push_to_nexus:
+    image: plugins/docker
+    repo: 'nexus.teamdigitale.test/ml-api'
+    registry: nexus.teamdigitale.test
+    tags: "test"
+    secrets: [ docker_username, docker_password ]
+    dockerfile: outbox-classification/web-api/Dockerfile 
+    insecure: true 
+
+  deploy:
+    image: 'lorenzosoligo/drone-kubernetes-plugin:1.0.0'
+    kubernetes_user: testkube
+    kubernetes_cluster: testkube
+    secrets: [ plugin_kubernetes_server, plugin_kubernetes_token ]
+    namespace: default
+    deployment: 'ml-api-deployment'
+    repo: 'nexus.teamdigitale.test/ml-api'
+    container: 'ml-api'
+    tag: 0.1.2

--- a/outbox-classification/web-api/Dockerfile
+++ b/outbox-classification/web-api/Dockerfile
@@ -2,10 +2,10 @@ FROM  python:3.6
 
 WORKDIR /app
 
-COPY requirements.txt /app
-COPY server.py /app
-COPY data /app/data
-COPY public /app/public
+COPY outbox-classification/web-api/requirements.txt /app
+COPY outbox-classification/web-api/server.py /app
+COPY outbox-classification/web-api/data /app/data
+COPY outbox-classification/web-api/public /app/public
 
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt


### PR DESCRIPTION
The `Dockerfile` in `outbox-classification/web-api` has been updated since Drone's Docker plugin uses the root of the repository as the root folder. However, building the Docker image will fail because the folder `outbox-classification/web-api/data`, used in the Dockerfile, is missing in the repository due to size limits.

The `.drone.yml` responsible for building the Docker image, pushing it to Nexus and updating the Kubernetes deployment has been placed in the root of the repository. The only thing that's left to do to enable the Drone pipeline is to activate the repository in Drone's UI